### PR TITLE
Fix system field to accept both string and array content blocks

### DIFF
--- a/internal/converter/messages.go
+++ b/internal/converter/messages.go
@@ -12,12 +12,12 @@ import (
 // string for the Claude CLI. Media content blocks are saved as temp files and
 // referenced in the prompt. Returns the prompt string and a list of temp file
 // paths that should be cleaned up after the CLI completes.
-func ConvertMessages(system string, messages []types.Message) (string, []string, error) {
+func ConvertMessages(system types.Content, messages []types.Message) (string, []string, error) {
 	var parts []string
 	var tempFiles []string
 
-	if system != "" {
-		parts = append(parts, "<system>\n"+system+"\n</system>")
+	if len(system.Blocks) > 0 {
+		parts = append(parts, "<system>\n"+system.TextContent()+"\n</system>")
 	}
 
 	for _, msg := range messages {

--- a/internal/converter/messages_test.go
+++ b/internal/converter/messages_test.go
@@ -10,7 +10,7 @@ func TestConvertMessages_SingleUser(t *testing.T) {
 	msgs := []types.Message{
 		{Role: "user", Content: types.Content{Blocks: []types.ContentBlock{{Type: "text", Text: "Hello"}}}},
 	}
-	prompt, files, err := ConvertMessages("", msgs)
+	prompt, files, err := ConvertMessages(types.Content{}, msgs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,11 +26,29 @@ func TestConvertMessages_WithSystem(t *testing.T) {
 	msgs := []types.Message{
 		{Role: "user", Content: types.Content{Blocks: []types.ContentBlock{{Type: "text", Text: "Hi"}}}},
 	}
-	prompt, _, err := ConvertMessages("You are helpful", msgs)
+	prompt, _, err := ConvertMessages(types.Content{Blocks: []types.ContentBlock{{Type: "text", Text: "You are helpful"}}}, msgs)
 	if err != nil {
 		t.Fatal(err)
 	}
 	expected := "<system>\nYou are helpful\n</system>\n\nHi"
+	if prompt != expected {
+		t.Fatalf("expected %q, got %q", expected, prompt)
+	}
+}
+
+func TestConvertMessages_WithSystemBlocks(t *testing.T) {
+	msgs := []types.Message{
+		{Role: "user", Content: types.Content{Blocks: []types.ContentBlock{{Type: "text", Text: "Hi"}}}},
+	}
+	system := types.Content{Blocks: []types.ContentBlock{
+		{Type: "text", Text: "You are helpful."},
+		{Type: "text", Text: " Be concise."},
+	}}
+	prompt, _, err := ConvertMessages(system, msgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "<system>\nYou are helpful. Be concise.\n</system>\n\nHi"
 	if prompt != expected {
 		t.Fatalf("expected %q, got %q", expected, prompt)
 	}
@@ -42,7 +60,7 @@ func TestConvertMessages_MultiTurn(t *testing.T) {
 		{Role: "assistant", Content: types.Content{Blocks: []types.ContentBlock{{Type: "text", Text: "Hi there!"}}}},
 		{Role: "user", Content: types.Content{Blocks: []types.ContentBlock{{Type: "text", Text: "How are you?"}}}},
 	}
-	prompt, _, err := ConvertMessages("", msgs)
+	prompt, _, err := ConvertMessages(types.Content{}, msgs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +71,7 @@ func TestConvertMessages_MultiTurn(t *testing.T) {
 }
 
 func TestConvertMessages_Empty(t *testing.T) {
-	prompt, files, err := ConvertMessages("", nil)
+	prompt, files, err := ConvertMessages(types.Content{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -320,6 +320,44 @@ func TestE2E_Messages_WithSystem(t *testing.T) {
 	}
 }
 
+func TestE2E_Messages_WithSystemArray(t *testing.T) {
+	ts, runner := testServer(&fakeRunner{
+		result: &types.CLIResult{
+			Result:     "Arrr!",
+			StopReason: "end_turn",
+		},
+	})
+	defer ts.Close()
+
+	resp := postMessages(t, ts.URL, `{
+		"model": "claude-sonnet-4",
+		"max_tokens": 1024,
+		"system": [{"type": "text", "text": "You are a pirate. You must include the word 'arrr' in every response."}],
+		"messages": [{"role": "user", "content": "Hello, how are you?"}]
+	}`)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, b)
+	}
+
+	result := decodeResponse(t, resp)
+	assertValidResponse(t, result)
+
+	if isRealCLI() {
+		if !strings.Contains(strings.ToLower(result.Content[0].Text), "arrr") {
+			t.Fatalf("expected pirate response containing 'arrr', got %q", result.Content[0].Text)
+		}
+		t.Logf("Pirate response (array system): %q", result.Content[0].Text)
+	} else {
+		expected := "<system>\nYou are a pirate. You must include the word 'arrr' in every response.\n</system>\n\nHello, how are you?"
+		if runner.gotPrompt != expected {
+			t.Fatalf("expected prompt:\n%s\ngot:\n%s", expected, runner.gotPrompt)
+		}
+	}
+}
+
 func TestE2E_Messages_WithImage(t *testing.T) {
 	imgB64 := loadTestFile(t, "cat.png")
 

--- a/internal/types/request.go
+++ b/internal/types/request.go
@@ -6,7 +6,7 @@ import "encoding/json"
 type MessagesRequest struct {
 	Model       string    `json:"model"`
 	Messages    []Message `json:"messages"`
-	System      string    `json:"system,omitempty"`
+	System      Content   `json:"system,omitempty"`
 	MaxTokens   int       `json:"max_tokens"`
 	Stream      bool      `json:"stream,omitempty"`
 	Temperature *float64  `json:"temperature,omitempty"`

--- a/internal/types/request_test.go
+++ b/internal/types/request_test.go
@@ -57,6 +57,41 @@ func TestContentUnmarshal_WithMedia(t *testing.T) {
 	}
 }
 
+func TestMessagesRequest_SystemAsString(t *testing.T) {
+	input := `{
+		"model": "claude-sonnet-4",
+		"max_tokens": 1024,
+		"system": "You are helpful",
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`
+	var req MessagesRequest
+	if err := json.Unmarshal([]byte(input), &req); err != nil {
+		t.Fatal(err)
+	}
+	if req.System.TextContent() != "You are helpful" {
+		t.Fatalf("expected 'You are helpful', got %q", req.System.TextContent())
+	}
+}
+
+func TestMessagesRequest_SystemAsArray(t *testing.T) {
+	input := `{
+		"model": "claude-sonnet-4",
+		"max_tokens": 1024,
+		"system": [{"type": "text", "text": "You are helpful."}],
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`
+	var req MessagesRequest
+	if err := json.Unmarshal([]byte(input), &req); err != nil {
+		t.Fatal(err)
+	}
+	if req.System.TextContent() != "You are helpful." {
+		t.Fatalf("expected 'You are helpful.', got %q", req.System.TextContent())
+	}
+	if len(req.System.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(req.System.Blocks))
+	}
+}
+
 func TestMessagesRequest_FullParse(t *testing.T) {
 	input := `{
 		"model": "claude-sonnet-4",


### PR DESCRIPTION
## Summary

- Reuse the existing `Content` type for `MessagesRequest.System` instead of `string`, so it accepts both `"system": "text"` and `"system": [{"type": "text", "text": "..."}]` formats
- Update `ConvertMessages` signature to match
- Add unit and E2E tests for array-based system prompts

Closes #1

## Test plan

- [x] `go test ./...` — all existing tests pass
- [x] `CLAUDE_E2E=1 go test ./internal/server/ -run TestE2E_Messages_WithSystem` — both string and array system prompts work against real CLI, with assertion that the system prompt influences behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)