### PR TITLE
Add --version flag to CLI

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,8 @@ builds:
   - env:
     - CGO_ENABLED=0
     main: ./cmd/claudecodeproxy
+    ldflags:
+    - -s -w -X main.version={{.Version}}
     goos:
     - darwin
     - linux

--- a/cmd/claudecodeproxy/main.go
+++ b/cmd/claudecodeproxy/main.go
@@ -11,14 +11,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var version = "dev"
+
 func main() {
 	var port int
 	var host string
 	var maxConcurrent int
 
 	rootCmd := &cobra.Command{
-		Use:   "claudecodeproxy",
-		Short: "Anthropic Messages API proxy for Claude CLI",
+		Use:     "claudecodeproxy",
+		Short:   "Anthropic Messages API proxy for Claude CLI",
+		Version: version,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Env vars override defaults but flags override env
 			if !cmd.Flags().Changed("port") {


### PR DESCRIPTION
## Summary
- Add a `version` variable to the CLI entrypoint, defaulting to `"dev"`, wired into Cobra's `Version` field to enable `--version`
- Configure GoReleaser ldflags (`-X main.version={{.Version}}`) to inject the Git tag at release time

## Test plan
- [x] `go build && ./claudecodeproxy --version` prints `claudecodeproxy version dev`
- [ ] Verify a tagged release injects the correct version string

🤖 Generated with [Claude Code](https://claude.com/claude-code)