### PR TITLE
Fix streaming: implement http.Flusher on logging middleware

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -87,6 +87,13 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
+// Flush implements http.Flusher so that streaming (SSE) works through the logging middleware.
+func (rw *responseWriter) Flush() {
+	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 // Unwrap allows the http.Flusher interface to pass through.
 func (rw *responseWriter) Unwrap() http.ResponseWriter {
 	return rw.ResponseWriter


### PR DESCRIPTION
## Summary
- The `withLogging` middleware's `responseWriter` did not implement `http.Flusher`, causing `StreamResponse()` to fail the type assertion and buffer the entire response instead of streaming SSE chunks
- Added a `Flush()` method that delegates to the underlying writer, restoring incremental streaming

Closes #3

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./...` passes
- [ ] Manual: `curl -N` streaming request confirms SSE chunks arrive incrementally

🤖 Generated with [Claude Code](https://claude.com/claude-code)