### PR TITLE
Clean streaming events to match Anthropic API spec

### DIFF
--- a/internal/converter/stream.go
+++ b/internal/converter/stream.go
@@ -21,9 +21,43 @@ type eventType struct {
 	Type string `json:"type"`
 }
 
+// Types used to clean message_start events to spec-compliant format.
+type messageStartEvent struct {
+	Type    string       `json:"type"`
+	Message startMessage `json:"message"`
+}
+
+type startMessage struct {
+	ID           string             `json:"id"`
+	Type         string             `json:"type"`
+	Role         string             `json:"role"`
+	Content      []AnthropicContent `json:"content"`
+	Model        string             `json:"model"`
+	StopReason   *string            `json:"stop_reason"`
+	StopSequence *string            `json:"stop_sequence"`
+	Usage        AnthropicUsage     `json:"usage"`
+}
+
+// Types used to clean message_delta events to spec-compliant format.
+type messageDeltaEvent struct {
+	Type  string         `json:"type"`
+	Delta messageDelta   `json:"delta"`
+	Usage deltaUsage     `json:"usage"`
+}
+
+type messageDelta struct {
+	StopReason   *string `json:"stop_reason"`
+	StopSequence *string `json:"stop_sequence"`
+}
+
+type deltaUsage struct {
+	OutputTokens int `json:"output_tokens"`
+}
+
 // StreamResponse reads stream-json lines from the CLI and writes SSE events
-// in the Anthropic streaming protocol.
-func StreamResponse(ctx context.Context, model string, stdout io.Reader, w http.ResponseWriter) error {
+// in the Anthropic streaming protocol. It cleans events to contain only
+// spec-compliant fields and remaps the model name.
+func StreamResponse(ctx context.Context, apiModel string, stdout io.Reader, w http.ResponseWriter) error {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		return fmt.Errorf("response writer does not support flushing")
@@ -61,10 +95,98 @@ func StreamResponse(ctx context.Context, model string, stdout io.Reader, w http.
 			continue
 		}
 
-		// Write the inner event directly as an SSE event -- it's already in Anthropic format
-		fmt.Fprintf(w, "event: %s\ndata: %s\n\n", et.Type, se.Event)
+		eventData, err := cleanEvent(et.Type, se.Event, apiModel)
+		if err != nil {
+			continue
+		}
+
+		fmt.Fprintf(w, "event: %s\ndata: %s\n\n", et.Type, eventData)
 		flusher.Flush()
 	}
 
 	return scanner.Err()
+}
+
+// cleanEvent strips non-standard fields from events that need it,
+// and passes through spec-compliant events unchanged.
+func cleanEvent(eventType string, raw json.RawMessage, apiModel string) ([]byte, error) {
+	switch eventType {
+	case "message_start":
+		return cleanMessageStart(raw, apiModel)
+	case "message_delta":
+		return cleanMessageDelta(raw)
+	default:
+		// content_block_start, content_block_delta, content_block_stop,
+		// message_stop, ping — pass through as-is.
+		return raw, nil
+	}
+}
+
+func cleanMessageStart(raw json.RawMessage, apiModel string) ([]byte, error) {
+	// Parse into a generic map to extract fields we need
+	var parsed struct {
+		Type    string `json:"type"`
+		Message struct {
+			ID           string             `json:"id"`
+			Type         string             `json:"type"`
+			Role         string             `json:"role"`
+			Content      []AnthropicContent `json:"content"`
+			Model        string             `json:"model"`
+			StopReason   *string            `json:"stop_reason"`
+			StopSequence *string            `json:"stop_sequence"`
+			Usage        struct {
+				InputTokens  int `json:"input_tokens"`
+				OutputTokens int `json:"output_tokens"`
+			} `json:"usage"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, err
+	}
+
+	clean := messageStartEvent{
+		Type: parsed.Type,
+		Message: startMessage{
+			ID:           parsed.Message.ID,
+			Type:         parsed.Message.Type,
+			Role:         parsed.Message.Role,
+			Content:      parsed.Message.Content,
+			Model:        apiModel,
+			StopReason:   parsed.Message.StopReason,
+			StopSequence: parsed.Message.StopSequence,
+			Usage: AnthropicUsage{
+				InputTokens:  parsed.Message.Usage.InputTokens,
+				OutputTokens: parsed.Message.Usage.OutputTokens,
+			},
+		},
+	}
+	return json.Marshal(clean)
+}
+
+func cleanMessageDelta(raw json.RawMessage) ([]byte, error) {
+	var parsed struct {
+		Type  string `json:"type"`
+		Delta struct {
+			StopReason   *string `json:"stop_reason"`
+			StopSequence *string `json:"stop_sequence"`
+		} `json:"delta"`
+		Usage struct {
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, err
+	}
+
+	clean := messageDeltaEvent{
+		Type: parsed.Type,
+		Delta: messageDelta{
+			StopReason:   parsed.Delta.StopReason,
+			StopSequence: parsed.Delta.StopSequence,
+		},
+		Usage: deltaUsage{
+			OutputTokens: parsed.Usage.OutputTokens,
+		},
+	}
+	return json.Marshal(clean)
 }

--- a/internal/converter/stream_test.go
+++ b/internal/converter/stream_test.go
@@ -1,0 +1,187 @@
+package converter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestStreamResponse_CleansMessageStart(t *testing.T) {
+	// Simulate CLI output with non-standard fields in message_start
+	cliEvent := `{"type":"stream_event","event":{"type":"message_start","message":{"id":"msg_abc123","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-6","stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":10,"cache_creation_input_tokens":100,"cache_read_input_tokens":200,"cache_creation":{"ephemeral_5m_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}}}}`
+
+	result := streamAndCapture(t, cliEvent, "claude-sonnet-4")
+
+	events := parseSSEEvents(t, result)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	ev := events[0]
+	if ev.name != "message_start" {
+		t.Fatalf("expected event name 'message_start', got %q", ev.name)
+	}
+
+	// Parse the cleaned event data
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(ev.data), &data); err != nil {
+		t.Fatalf("failed to parse event data: %v", err)
+	}
+
+	msg := data["message"].(map[string]interface{})
+
+	// Model should be remapped to API model
+	if msg["model"] != "claude-sonnet-4" {
+		t.Errorf("expected model 'claude-sonnet-4', got %v", msg["model"])
+	}
+
+	// Non-standard fields should be absent
+	if _, ok := msg["stop_details"]; ok {
+		t.Error("stop_details should be stripped from message")
+	}
+
+	usage := msg["usage"].(map[string]interface{})
+	for _, field := range []string{"cache_creation_input_tokens", "cache_read_input_tokens", "cache_creation", "service_tier", "inference_geo"} {
+		if _, ok := usage[field]; ok {
+			t.Errorf("non-standard field %q should be stripped from usage", field)
+		}
+	}
+
+	// Standard fields should be present
+	if usage["input_tokens"] != float64(10) {
+		t.Errorf("expected input_tokens=10, got %v", usage["input_tokens"])
+	}
+	if usage["output_tokens"] != float64(1) {
+		t.Errorf("expected output_tokens=1, got %v", usage["output_tokens"])
+	}
+}
+
+func TestStreamResponse_CleansMessageDelta(t *testing.T) {
+	cliEvent := `{"type":"stream_event","event":{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":10,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0},"context_management":{"applied_edits":[]}}}`
+
+	result := streamAndCapture(t, cliEvent, "claude-sonnet-4")
+
+	events := parseSSEEvents(t, result)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(events[0].data), &data); err != nil {
+		t.Fatalf("failed to parse event data: %v", err)
+	}
+
+	// Non-standard top-level fields should be absent
+	if _, ok := data["context_management"]; ok {
+		t.Error("context_management should be stripped")
+	}
+
+	delta := data["delta"].(map[string]interface{})
+	if _, ok := delta["stop_details"]; ok {
+		t.Error("stop_details should be stripped from delta")
+	}
+	if delta["stop_reason"] != "end_turn" {
+		t.Errorf("expected stop_reason 'end_turn', got %v", delta["stop_reason"])
+	}
+
+	usage := data["usage"].(map[string]interface{})
+	if usage["output_tokens"] != float64(50) {
+		t.Errorf("expected output_tokens=50, got %v", usage["output_tokens"])
+	}
+	// Usage should only have output_tokens for message_delta
+	if _, ok := usage["input_tokens"]; ok {
+		t.Error("input_tokens should not be in message_delta usage")
+	}
+}
+
+func TestStreamResponse_PassesThroughContentBlockEvents(t *testing.T) {
+	cliEvent := `{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}}`
+
+	result := streamAndCapture(t, cliEvent, "claude-sonnet-4")
+
+	events := parseSSEEvents(t, result)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	// Content block events should pass through unchanged
+	var original, cleaned map[string]interface{}
+	origJSON := `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}`
+	json.Unmarshal([]byte(origJSON), &original)
+	json.Unmarshal([]byte(events[0].data), &cleaned)
+
+	origBytes, _ := json.Marshal(original)
+	cleanBytes, _ := json.Marshal(cleaned)
+	if string(origBytes) != string(cleanBytes) {
+		t.Errorf("content_block_delta should pass through unchanged.\nExpected: %s\nGot:      %s", origBytes, cleanBytes)
+	}
+}
+
+func TestStreamResponse_SkipsNonStreamEvents(t *testing.T) {
+	input := strings.Join([]string{
+		`{"type":"system","message":"hello"}`,
+		`{"type":"stream_event","event":{"type":"ping"}}`,
+		`{"type":"result","result":"done"}`,
+	}, "\n")
+
+	result := streamAndCapture(t, input, "claude-sonnet-4")
+
+	events := parseSSEEvents(t, result)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event (ping), got %d", len(events))
+	}
+	if events[0].name != "ping" {
+		t.Errorf("expected ping event, got %q", events[0].name)
+	}
+}
+
+// --- helpers ---
+
+type sseEvent struct {
+	name string
+	data string
+}
+
+func streamAndCapture(t *testing.T, input string, apiModel string) string {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	reader := strings.NewReader(input)
+
+	err := StreamResponse(context.Background(), apiModel, reader, recorder)
+	if err != nil {
+		t.Fatalf("StreamResponse error: %v", err)
+	}
+
+	if ct := recorder.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("expected Content-Type 'text/event-stream', got %q", ct)
+	}
+
+	return recorder.Body.String()
+}
+
+func parseSSEEvents(t *testing.T, raw string) []sseEvent {
+	t.Helper()
+	var events []sseEvent
+	blocks := strings.Split(strings.TrimSpace(raw), "\n\n")
+	for _, block := range blocks {
+		if block == "" {
+			continue
+		}
+		var ev sseEvent
+		for _, line := range strings.Split(block, "\n") {
+			if strings.HasPrefix(line, "event: ") {
+				ev.name = strings.TrimPrefix(line, "event: ")
+			} else if strings.HasPrefix(line, "data: ") {
+				ev.data = strings.TrimPrefix(line, "data: ")
+			}
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+// Ensure httptest.ResponseRecorder implements http.Flusher (compile-time check).
+var _ http.Flusher = httptest.NewRecorder()

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -52,7 +52,7 @@ func (s *Server) MessagesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Stream {
-		s.handleStreaming(w, r, cliModel, prompt, tempDir)
+		s.handleStreaming(w, r, req.Model, cliModel, prompt, tempDir)
 	} else {
 		s.handleNonStreaming(w, r, req.Model, cliModel, prompt, tempDir)
 	}
@@ -71,7 +71,7 @@ func (s *Server) handleNonStreaming(w http.ResponseWriter, r *http.Request, apiM
 	json.NewEncoder(w).Encode(resp)
 }
 
-func (s *Server) handleStreaming(w http.ResponseWriter, r *http.Request, cliModel, prompt, tempDir string) {
+func (s *Server) handleStreaming(w http.ResponseWriter, r *http.Request, apiModel, cliModel, prompt, tempDir string) {
 	stdout, wait, err := s.runner.RunStreaming(r.Context(), cliModel, prompt, tempDir)
 	if err != nil {
 		log.Printf("CLI streaming error: %v", err)
@@ -79,7 +79,7 @@ func (s *Server) handleStreaming(w http.ResponseWriter, r *http.Request, cliMode
 		return
 	}
 
-	if err := converter.StreamResponse(r.Context(), cliModel, stdout, w); err != nil {
+	if err := converter.StreamResponse(r.Context(), apiModel, stdout, w); err != nil {
 		log.Printf("streaming error: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- Strip non-standard fields (`stop_details`, `cache_creation_input_tokens`, `cache_read_input_tokens`, `cache_creation`, `service_tier`, `inference_geo`, `context_management`) from `message_start` and `message_delta` SSE events
- Remap model name to the client-requested API model (e.g., `claude-sonnet-4`) instead of the CLI's internal identifier (e.g., `claude-sonnet-4-6`)
- Pass through `content_block_*`, `message_stop`, and `ping` events unchanged

Closes #7

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./...` — new tests in `stream_test.go` verify field stripping, model remapping, and passthrough behavior
- [ ] Manual: streaming request with strict client (e.g., OpenClaw) no longer rejects events

🤖 Generated with [Claude Code](https://claude.com/claude-code)