### PR TITLE
Add passthrough and augmented proxy modes

### DIFF
--- a/cmd/claudecodeproxy/main.go
+++ b/cmd/claudecodeproxy/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 
+	"claudecodeproxy/internal/proxy"
 	"claudecodeproxy/internal/server"
 
 	"github.com/spf13/cobra"
@@ -17,6 +18,7 @@ func main() {
 	var port int
 	var host string
 	var maxConcurrent int
+	var mode string
 
 	rootCmd := &cobra.Command{
 		Use:     "claudecodeproxy",
@@ -43,12 +45,35 @@ func main() {
 					}
 				}
 			}
-
-			if os.Getenv("CLAUDE_CODE_OAUTH_TOKEN") == "" {
-				fmt.Fprintln(os.Stderr, "warning: CLAUDE_CODE_OAUTH_TOKEN is not set")
+			if !cmd.Flags().Changed("mode") {
+				if m := os.Getenv("MODE"); m != "" {
+					mode = m
+				}
 			}
 
-			srv := server.New(host, port, maxConcurrent)
+			baseURL := os.Getenv("ANTHROPIC_BASE_URL")
+
+			var srv *server.Server
+			switch mode {
+			case "cli":
+				if os.Getenv("CLAUDE_CODE_OAUTH_TOKEN") == "" {
+					fmt.Fprintln(os.Stderr, "warning: CLAUDE_CODE_OAUTH_TOKEN is not set")
+				}
+				srv = server.NewCLI(host, port, maxConcurrent)
+			case "passthrough", "augmented":
+				auth, err := resolveAuth()
+				if err != nil {
+					return err
+				}
+				if mode == "passthrough" {
+					srv = server.NewPassthrough(host, port, auth, baseURL)
+				} else {
+					srv = server.NewAugmented(host, port, auth, baseURL)
+				}
+			default:
+				return fmt.Errorf("unknown mode: %s (valid: cli, passthrough, augmented)", mode)
+			}
+
 			return srv.Start(context.Background())
 		},
 	}
@@ -56,8 +81,21 @@ func main() {
 	rootCmd.Flags().IntVarP(&port, "port", "p", 3456, "listen port")
 	rootCmd.Flags().StringVar(&host, "host", "127.0.0.1", "bind address")
 	rootCmd.Flags().IntVar(&maxConcurrent, "max-concurrent", 10, "max concurrent CLI processes")
+	rootCmd.Flags().StringVar(&mode, "mode", "cli", "proxy mode: cli, passthrough, augmented")
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
+}
+
+// resolveAuth builds AuthConfig from environment variables.
+// Prefers CLAUDE_CODE_OAUTH_TOKEN, falls back to ANTHROPIC_API_KEY.
+func resolveAuth() (proxy.AuthConfig, error) {
+	if token := os.Getenv("CLAUDE_CODE_OAUTH_TOKEN"); token != "" {
+		return proxy.AuthConfig{OAuthToken: token}, nil
+	}
+	if key := os.Getenv("ANTHROPIC_API_KEY"); key != "" {
+		return proxy.AuthConfig{APIKey: key}, nil
+	}
+	return proxy.AuthConfig{}, fmt.Errorf("CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY required for passthrough/augmented mode")
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,289 @@
+# Architecture: claudecodeproxy
+
+## Overview
+
+claudecodeproxy is an HTTP proxy that exposes an [Anthropic Messages API](https://docs.anthropic.com/en/api/messages) endpoint. It supports three operating modes:
+
+| Mode | How it works | Use case |
+|------|-------------|----------|
+| **cli** | Shells out to `claude -p` | Use Claude Max subscription via CLI |
+| **passthrough** | Reverse proxy to `api.anthropic.com` | Auth/billing proxy, no body modification |
+| **augmented** | Reverse proxy + injects headers, attribution, metadata | Full Claude Code impersonation |
+
+```mermaid
+graph TB
+    Client["Any Anthropic SDK Client"] -->|"POST /v1/messages"| Proxy["claudecodeproxy :3456"]
+
+    Proxy -->|"--mode cli"| CLI["claude -p<br/>stdin/stdout"]
+    Proxy -->|"--mode passthrough"| API1["api.anthropic.com<br/>(auth headers only)"]
+    Proxy -->|"--mode augmented"| API2["api.anthropic.com<br/>(headers + body mods)"]
+
+    CLI -->|"stdout"| Proxy
+    API1 -->|"response"| Proxy
+    API2 -->|"response"| Proxy
+    Proxy -->|"Anthropic API response"| Client
+```
+
+## Mode selection
+
+The mode is selected via `--mode` flag or `MODE` env var. Each mode uses a different `messagesHandler` function mounted on the same HTTP server:
+
+```mermaid
+flowchart TD
+    Start["main.go"] --> Mode{"--mode ?"}
+
+    Mode -->|cli| NewCLI["server.NewCLI()"]
+    Mode -->|passthrough| NewPass["server.NewPassthrough()"]
+    Mode -->|augmented| NewAug["server.NewAugmented()"]
+
+    NewCLI --> MakeCLI["makeCLIHandler(runner)"]
+    NewPass --> PassH["proxy.Passthrough.Handle"]
+    NewAug --> AugH["proxy.Augmented.Handle"]
+
+    MakeCLI --> Mux["mux.HandleFunc('POST /v1/messages', handler)"]
+    PassH --> Mux
+    AugH --> Mux
+
+    Mux --> Server["http.Server.ListenAndServe()"]
+```
+
+## Authentication
+
+The proxy supports two auth methods, resolved from environment variables:
+
+```mermaid
+flowchart TD
+    Resolve["resolveAuth()"] --> OAuth{"CLAUDE_CODE_OAUTH_TOKEN<br/>set?"}
+    OAuth -->|Yes| Bearer["AuthConfig{OAuthToken: token}"]
+    OAuth -->|No| APIKey{"ANTHROPIC_API_KEY<br/>set?"}
+    APIKey -->|Yes| XKey["AuthConfig{APIKey: key}"]
+    APIKey -->|No| Err["Error: no credentials"]
+
+    Bearer --> Headers1["Authorization: Bearer token<br/>anthropic-beta: oauth-2025-04-20"]
+    XKey --> Headers2["x-api-key: key"]
+```
+
+| Auth method | Header | Required beta | Source |
+|------------|--------|---------------|--------|
+| OAuth (Claude Max) | `Authorization: Bearer <token>` | `oauth-2025-04-20` | `CLAUDE_CODE_OAUTH_TOKEN` |
+| API key | `x-api-key: <key>` | none | `ANTHROPIC_API_KEY` |
+
+## Mode: CLI
+
+The original mode. Converts the Anthropic Messages API request into a text prompt and shells out to the `claude` CLI.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant P as Proxy
+    participant CLI as claude -p
+
+    C->>P: POST /v1/messages<br/>{model, messages, system}
+    P->>P: Validate & map model<br/>(claude-sonnet-4 -> sonnet)
+    P->>P: Flatten messages to prompt string
+    P->>P: Decode media to /tmp files
+
+    P->>CLI: stdin: prompt text<br/>flags: --output-format json<br/>--model sonnet
+    CLI-->>P: stdout: JSON result
+    P->>P: Build Anthropic response
+    P-->>C: 200 {id, type, content, usage}
+```
+
+**Limitations:**
+- Messages are flattened to text (loses structured format)
+- Only text responses (no tool_use blocks)
+- temperature/max_tokens parsed but not forwarded
+- Only 3 models supported (sonnet, opus, haiku)
+- Process spawn overhead per request
+
+## Mode: Passthrough
+
+Pure reverse proxy. Forwards the request body unchanged to `api.anthropic.com`, injecting auth and identity headers.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant P as Proxy
+    participant API as api.anthropic.com
+
+    C->>P: POST /v1/messages<br/>{any valid request}
+    P->>P: Read request body
+    P->>API: POST /v1/messages<br/>+ x-api-key or Authorization<br/>+ anthropic-version<br/>+ User-Agent, x-app, session ID
+    API-->>P: Response (JSON or SSE stream)
+    P-->>C: Response (forwarded as-is)
+```
+
+**Headers injected:**
+
+| Header | Value |
+|--------|-------|
+| `anthropic-version` | `2023-06-01` |
+| `x-api-key` or `Authorization` | From auth config |
+| `User-Agent` | `claude-cli/2.1.91 (external, cli)` |
+| `x-app` | `cli` |
+| `X-Claude-Code-Session-Id` | UUID (stable per proxy instance) |
+| `x-client-request-id` | UUID (unique per request) |
+
+Client-provided `anthropic-beta` headers are passed through and merged with any auth-required betas.
+
+## Mode: Augmented
+
+Builds on passthrough by also modifying the request body to match what the real Claude Code CLI sends. This includes the attribution header, system prompt prefix, beta headers, and metadata.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant P as Proxy
+    participant API as api.anthropic.com
+
+    C->>P: POST /v1/messages<br/>{model, messages, system?}
+
+    rect rgb(240, 248, 255)
+        Note over P: Request augmentation
+        P->>P: Parse request body
+        P->>P: Extract model for beta headers
+        P->>P: Extract first user message text
+        P->>P: Compute fingerprint (SHA256)
+        P->>P: Prepend attribution + identity to system prompt
+        P->>P: Inject metadata (device_id, session_id)
+        P->>P: Set anthropic-beta headers for model
+    end
+
+    P->>API: POST /v1/messages<br/>(modified body + all headers)
+    API-->>P: Response
+    P-->>C: Response (forwarded as-is)
+```
+
+### Attribution header
+
+Embedded as the first line of the system prompt (not an HTTP header):
+
+```
+x-anthropic-billing-header: cc_version=2.1.91.<fingerprint>; cc_entrypoint=cli;
+You are Claude Code, Anthropic's official CLI for Claude.
+```
+
+### Fingerprint computation
+
+Replicates the algorithm from `claude-code/utils/fingerprint.ts`:
+
+```mermaid
+flowchart LR
+    Msg["First user message text"] --> Extract["chars at indices<br/>[4, 7, 20]<br/>('0' if missing)"]
+    Extract --> Concat["salt + chars + version"]
+    Salt["59cf53e54c78"] --> Concat
+    Ver["2.1.91"] --> Concat
+    Concat --> Hash["SHA256"]
+    Hash --> Slice["First 3 hex chars"]
+    Slice --> FP["e.g. 'e96'"]
+```
+
+### System prompt injection
+
+The augmented handler prepends the attribution and identity prefix to whatever system prompt the client provided:
+
+```mermaid
+flowchart TD
+    Input{"Client system<br/>prompt format?"} -->|None| Create["Create array:<br/>[{type: text, text: prefix}]"]
+    Input -->|String| Prepend["Prepend prefix + \\n\\n + original"]
+    Input -->|"Array of blocks"| Insert["Insert prefix block<br/>at index 0"]
+```
+
+### Metadata injection
+
+Added to the request body as:
+
+```json
+{
+  "metadata": {
+    "user_id": "{\"device_id\":\"<uuid>\",\"account_uuid\":\"\",\"session_id\":\"<uuid>\"}"
+  }
+}
+```
+
+### Beta headers (per model)
+
+| Model family | Beta headers injected |
+|-------------|----------------------|
+| Claude 4+ (non-haiku) | `claude-code-20250219`, `interleaved-thinking-2025-05-14`, `context-management-2025-06-27` |
+| Claude 4+ (haiku) | `interleaved-thinking-2025-05-14`, `context-management-2025-06-27` |
+| Claude 3.x | `claude-code-20250219` |
+
+## Streaming
+
+All three modes support SSE streaming. The mechanism differs by mode:
+
+```mermaid
+flowchart LR
+    subgraph CLI Mode
+        CLIStream["CLI stdout<br/>(stream_event NDJSON)"] --> Unwrap["Unwrap envelope"] --> SSE1["SSE frames<br/>to client"]
+    end
+
+    subgraph Passthrough / Augmented
+        APIStream["API response<br/>(SSE stream)"] --> Forward["Copy bytes<br/>+ Flush()"] --> SSE2["SSE frames<br/>to client"]
+    end
+```
+
+- **CLI mode**: The CLI emits `{"type":"stream_event","event":{...}}` lines. The proxy unwraps the envelope and writes standard SSE frames (`event: ...\ndata: ...\n\n`).
+- **Passthrough/Augmented**: The API responds with standard SSE. The proxy copies the response body to the client, flushing after each chunk for low-latency streaming.
+
+## Project structure
+
+```
+cmd/claudecodeproxy/
+    main.go                    # Cobra CLI: flags, env vars, mode selection
+internal/
+    proxy/
+        proxy.go               # Passthrough handler, AuthConfig, streaming
+        augmented.go            # Augmented handler: fingerprint, attribution, metadata, betas
+    server/
+        server.go              # HTTP server, mode-specific constructors, middleware
+        handlers.go            # CLI mode handler (makeCLIHandler), health endpoint
+    claude/
+        cli.go                 # Runner interface, CLIRunner, subprocess + semaphore
+        models.go              # Model name mapping (CLI mode only)
+    converter/
+        messages.go            # Messages -> CLI prompt string (CLI mode only)
+        response.go            # CLI result -> Anthropic response (CLI mode only)
+        stream.go              # stream_event unwrapping -> SSE (CLI mode only)
+    media/
+        media.go               # Base64 decode, temp file save/cleanup (CLI mode only)
+    types/
+        request.go             # Anthropic request types, Content unmarshaler
+        cliresult.go           # CLI JSON output types
+```
+
+## Configuration
+
+| Source | Variable | Default | Description |
+|--------|----------|---------|-------------|
+| Flag | `--mode` | `cli` | Proxy mode: cli, passthrough, augmented |
+| Flag | `--port` / `-p` | 3456 | Listen port |
+| Flag | `--host` | 127.0.0.1 | Bind address |
+| Flag | `--max-concurrent` | 10 | Max concurrent CLI processes (cli mode) |
+| Env | `MODE` | `cli` | Proxy mode (overridden by flag) |
+| Env | `CLAUDE_CODE_OAUTH_TOKEN` | - | OAuth token (cli + proxy modes) |
+| Env | `ANTHROPIC_API_KEY` | - | API key (proxy modes only) |
+| Env | `ANTHROPIC_BASE_URL` | `https://api.anthropic.com` | Upstream API URL (proxy modes) |
+
+Precedence: flags > env vars > defaults.
+
+## Testing
+
+```mermaid
+flowchart TD
+    Tests["go test ./..."] --> ServerTests["internal/server/"]
+    Tests --> ProxyTests["internal/proxy/"]
+    Tests --> OtherTests["claude/, converter/,<br/>media/, types/"]
+
+    ServerTests --> MockMode{"CLAUDE_E2E=1?"}
+    MockMode -->|No| Fake["fakeRunner:<br/>canned responses"]
+    MockMode -->|Yes| Real["Real claude CLI"]
+
+    ProxyTests --> MockUpstream["httptest.Server<br/>mock API upstream"]
+    MockUpstream --> PassTests["Passthrough tests:<br/>auth, headers, streaming,<br/>errors, forwarding"]
+    MockUpstream --> AugTests["Augmented tests:<br/>betas, attribution,<br/>fingerprint, metadata,<br/>system prompt injection"]
+```
+
+- `go test ./...` -- all tests, mock mode (~1s)
+- `CLAUDE_E2E=1 go test ./internal/server/ -timeout 180s` -- real CLI integration tests

--- a/internal/proxy/augmented.go
+++ b/internal/proxy/augmented.go
@@ -2,26 +2,36 @@ package proxy
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 // Augmented wraps a Passthrough proxy, injecting model-appropriate beta headers
-// before forwarding. This gives clients the same API behavior that Claude Code gets.
+// and modifying the request body to include Claude Code's attribution header,
+// system prompt prefix, and metadata. This makes requests look identical to
+// those sent by the real Claude Code CLI.
 type Augmented struct {
-	pass *Passthrough
+	pass     *Passthrough
+	deviceID string // stable per proxy instance
 }
 
 // NewAugmented creates an augmented proxy. If baseURL is empty, defaults to
 // https://api.anthropic.com.
 func NewAugmented(auth AuthConfig, baseURL string) *Augmented {
-	return &Augmented{pass: NewPassthrough(auth, baseURL)}
+	return &Augmented{
+		pass:     NewPassthrough(auth, baseURL),
+		deviceID: uuid.New().String(),
+	}
 }
 
-// Handle reads the request to extract the model name, injects beta headers,
-// then delegates to the passthrough handler.
+// Handle reads the request, injects beta headers, modifies the body to add
+// attribution and metadata, then delegates to the passthrough handler.
 func (a *Augmented) Handle(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -29,23 +39,174 @@ func (a *Augmented) Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract model from request (minimal parse)
-	var partial struct {
-		Model string `json:"model"`
+	// Parse the request body
+	var req map[string]json.RawMessage
+	if err := json.Unmarshal(body, &req); err != nil {
+		// Let passthrough forward the malformed body — upstream will return the error
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		a.pass.Handle(w, r)
+		return
 	}
-	json.Unmarshal(body, &partial) // best-effort; passthrough will get the real error from upstream
+
+	// Extract model for beta headers
+	var model string
+	if raw, ok := req["model"]; ok {
+		json.Unmarshal(raw, &model)
+	}
 
 	// Inject beta headers
-	betas := betaHeadersForModel(partial.Model)
+	betas := betaHeadersForModel(model)
 	existing := r.Header.Get("anthropic-beta")
 	merged := mergeBetas(existing, betas)
 	if merged != "" {
 		r.Header.Set("anthropic-beta", merged)
 	}
 
-	// Restore body and delegate
-	r.Body = io.NopCloser(bytes.NewReader(body))
+	// Extract first user message text for fingerprinting
+	firstMsgText := extractFirstUserMessageText(req)
+
+	// Compute fingerprint and build attribution line
+	fingerprint := computeFingerprint(firstMsgText, claudeCodeVersion)
+	attribution := fmt.Sprintf("x-anthropic-billing-header: cc_version=%s.%s; cc_entrypoint=cli;", claudeCodeVersion, fingerprint)
+
+	// Inject attribution + Claude Code prefix into system prompt
+	injectSystemPrefix(req, attribution)
+
+	// Inject metadata
+	injectMetadata(req, a.deviceID, a.pass.sessionID)
+
+	// Re-serialize and forward
+	modified, err := json.Marshal(req)
+	if err != nil {
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		a.pass.Handle(w, r)
+		return
+	}
+
+	r.Body = io.NopCloser(bytes.NewReader(modified))
+	r.ContentLength = int64(len(modified))
 	a.pass.Handle(w, r)
+}
+
+// fingerprintSalt matches the hardcoded salt in claude-code/utils/fingerprint.ts
+const fingerprintSalt = "59cf53e54c78"
+
+// computeFingerprint replicates claude-code's fingerprint algorithm:
+// SHA256(salt + msg[4] + msg[7] + msg[20] + version)[:3]
+func computeFingerprint(messageText, version string) string {
+	indices := [3]int{4, 7, 20}
+	var chars [3]byte
+	for i, idx := range indices {
+		if idx < len(messageText) {
+			chars[i] = messageText[idx]
+		} else {
+			chars[i] = '0'
+		}
+	}
+
+	input := fmt.Sprintf("%s%s%s", fingerprintSalt, string(chars[:]), version)
+	hash := sha256.Sum256([]byte(input))
+	return fmt.Sprintf("%x", hash[:2])[:3] // first 3 hex chars
+}
+
+// extractFirstUserMessageText finds the text content of the first user message.
+func extractFirstUserMessageText(req map[string]json.RawMessage) string {
+	raw, ok := req["messages"]
+	if !ok {
+		return ""
+	}
+
+	var messages []struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &messages); err != nil {
+		return ""
+	}
+
+	for _, msg := range messages {
+		if msg.Role != "user" {
+			continue
+		}
+		// Content can be a string or array of blocks
+		var text string
+		if err := json.Unmarshal(msg.Content, &text); err == nil {
+			return text
+		}
+		var blocks []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal(msg.Content, &blocks); err == nil {
+			for _, b := range blocks {
+				if b.Type == "text" {
+					return b.Text
+				}
+			}
+		}
+		return ""
+	}
+	return ""
+}
+
+// injectSystemPrefix prepends the attribution header and Claude Code identity
+// to the system prompt. Handles both string and array-of-blocks formats,
+// or creates a new system field if none exists.
+func injectSystemPrefix(req map[string]json.RawMessage, attribution string) {
+	prefix := attribution + "\n" + "You are Claude Code, Anthropic's official CLI for Claude."
+
+	raw, exists := req["system"]
+	if !exists {
+		// No system prompt — create one
+		block, _ := json.Marshal([]map[string]string{
+			{"type": "text", "text": prefix},
+		})
+		req["system"] = block
+		return
+	}
+
+	// Try as string
+	var systemStr string
+	if err := json.Unmarshal(raw, &systemStr); err == nil {
+		combined := prefix + "\n\n" + systemStr
+		encoded, _ := json.Marshal(combined)
+		req["system"] = encoded
+		return
+	}
+
+	// Try as array of text blocks
+	var existingBlocks []json.RawMessage
+	if err := json.Unmarshal(raw, &existingBlocks); err == nil {
+		prefixBlock, _ := json.Marshal(map[string]string{
+			"type": "text",
+			"text": prefix,
+		})
+		result := append([]json.RawMessage{prefixBlock}, existingBlocks...)
+		encoded, _ := json.Marshal(result)
+		req["system"] = encoded
+		return
+	}
+
+	// Unknown format — prepend as string
+	block, _ := json.Marshal([]map[string]string{
+		{"type": "text", "text": prefix},
+	})
+	req["system"] = block
+}
+
+// injectMetadata adds the metadata.user_id field matching Claude Code's format.
+func injectMetadata(req map[string]json.RawMessage, deviceID, sessionID string) {
+	userIDObj := map[string]string{
+		"device_id":    deviceID,
+		"account_uuid": "",
+		"session_id":   sessionID,
+	}
+	userIDJSON, _ := json.Marshal(userIDObj)
+	metadata := map[string]string{
+		"user_id": string(userIDJSON),
+	}
+	encoded, _ := json.Marshal(metadata)
+	req["metadata"] = encoded
 }
 
 // betaHeadersForModel returns the beta headers that Claude Code would send for

--- a/internal/proxy/augmented.go
+++ b/internal/proxy/augmented.go
@@ -1,0 +1,101 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Augmented wraps a Passthrough proxy, injecting model-appropriate beta headers
+// before forwarding. This gives clients the same API behavior that Claude Code gets.
+type Augmented struct {
+	pass *Passthrough
+}
+
+// NewAugmented creates an augmented proxy. If baseURL is empty, defaults to
+// https://api.anthropic.com.
+func NewAugmented(auth AuthConfig, baseURL string) *Augmented {
+	return &Augmented{pass: NewPassthrough(auth, baseURL)}
+}
+
+// Handle reads the request to extract the model name, injects beta headers,
+// then delegates to the passthrough handler.
+func (a *Augmented) Handle(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeProxyError(w, http.StatusBadRequest, "invalid_request_error", "failed to read request body")
+		return
+	}
+
+	// Extract model from request (minimal parse)
+	var partial struct {
+		Model string `json:"model"`
+	}
+	json.Unmarshal(body, &partial) // best-effort; passthrough will get the real error from upstream
+
+	// Inject beta headers
+	betas := betaHeadersForModel(partial.Model)
+	existing := r.Header.Get("anthropic-beta")
+	merged := mergeBetas(existing, betas)
+	if merged != "" {
+		r.Header.Set("anthropic-beta", merged)
+	}
+
+	// Restore body and delegate
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	a.pass.Handle(w, r)
+}
+
+// betaHeadersForModel returns the beta headers that Claude Code would send for
+// the given model. Derived from claude-code/constants/betas.ts and utils/betas.ts.
+func betaHeadersForModel(model string) []string {
+	var betas []string
+	lower := strings.ToLower(model)
+
+	// claude-code-20250219: core Claude Code behavior (non-haiku models)
+	if !strings.Contains(lower, "haiku") {
+		betas = append(betas, "claude-code-20250219")
+	}
+
+	// interleaved-thinking-2025-05-14: extended thinking (claude-4+ models)
+	if !strings.Contains(lower, "claude-3-") {
+		betas = append(betas, "interleaved-thinking-2025-05-14")
+	}
+
+	// context-management-2025-06-27: thinking preservation (claude-4+ models)
+	if !strings.Contains(lower, "claude-3-") {
+		betas = append(betas, "context-management-2025-06-27")
+	}
+
+	return betas
+}
+
+// mergeBetas combines existing comma-separated betas with additional ones,
+// removing duplicates.
+func mergeBetas(existing string, additional []string) string {
+	seen := make(map[string]bool)
+	var result []string
+
+	// Parse existing
+	if existing != "" {
+		for _, b := range strings.Split(existing, ",") {
+			b = strings.TrimSpace(b)
+			if b != "" && !seen[b] {
+				seen[b] = true
+				result = append(result, b)
+			}
+		}
+	}
+
+	// Add new ones
+	for _, b := range additional {
+		if !seen[b] {
+			seen[b] = true
+			result = append(result, b)
+		}
+	}
+
+	return strings.Join(result, ",")
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,0 +1,132 @@
+package proxy
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+// claudeCodeVersion is the Claude CLI version we impersonate. Requests
+// without a matching User-Agent may be rate-limited differently.
+const claudeCodeVersion = "2.1.91"
+
+// AuthConfig holds authentication credentials for the Anthropic API.
+// Exactly one of APIKey or OAuthToken should be set.
+type AuthConfig struct {
+	APIKey     string // uses x-api-key header
+	OAuthToken string // uses Authorization: Bearer header + oauth beta
+}
+
+// Passthrough is a reverse proxy that forwards requests to the Anthropic API,
+// injecting authentication headers. It does not parse or modify request/response bodies.
+type Passthrough struct {
+	auth      AuthConfig
+	baseURL   string
+	sessionID string // stable per proxy instance, like Claude Code's session ID
+	client    *http.Client
+}
+
+// NewPassthrough creates a passthrough proxy. If baseURL is empty, defaults to
+// https://api.anthropic.com.
+func NewPassthrough(auth AuthConfig, baseURL string) *Passthrough {
+	if baseURL == "" {
+		baseURL = "https://api.anthropic.com"
+	}
+	return &Passthrough{
+		auth:      auth,
+		baseURL:   baseURL,
+		sessionID: uuid.New().String(),
+		client:    &http.Client{},
+	}
+}
+
+// Handle forwards the incoming request to the Anthropic API and streams the
+// response back. Works for both streaming (SSE) and non-streaming responses.
+func (p *Passthrough) Handle(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeProxyError(w, http.StatusBadRequest, "invalid_request_error", "failed to read request body")
+		return
+	}
+
+	upstream, err := http.NewRequestWithContext(r.Context(), "POST", p.baseURL+"/v1/messages", bytes.NewReader(body))
+	if err != nil {
+		writeProxyError(w, http.StatusInternalServerError, "api_error", "failed to create upstream request")
+		return
+	}
+
+	upstream.Header.Set("Content-Type", "application/json")
+	upstream.Header.Set("anthropic-version", "2023-06-01")
+	upstream.Header.Set("x-app", "cli")
+	upstream.Header.Set("User-Agent", "claude-cli/"+claudeCodeVersion+" (external, cli)")
+	upstream.Header.Set("X-Claude-Code-Session-Id", p.sessionID)
+	upstream.Header.Set("x-client-request-id", uuid.New().String())
+	p.auth.setHeaders(upstream.Header)
+
+	// Pass through client-provided beta headers (merge with auth betas)
+	if beta := r.Header.Get("anthropic-beta"); beta != "" {
+		if existing := upstream.Header.Get("anthropic-beta"); existing != "" {
+			upstream.Header.Set("anthropic-beta", existing+","+beta)
+		} else {
+			upstream.Header.Set("anthropic-beta", beta)
+		}
+	}
+
+	resp, err := p.client.Do(upstream)
+	if err != nil {
+		log.Printf("upstream request failed: %v", err)
+		writeProxyError(w, http.StatusBadGateway, "api_error", "upstream request failed: "+err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	// Copy response headers
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+
+	// Stream response body back, flushing for SSE support
+	streamBody(w, resp.Body)
+}
+
+// setHeaders sets the appropriate authentication headers on the request.
+func (a AuthConfig) setHeaders(h http.Header) {
+	if a.OAuthToken != "" {
+		h.Set("Authorization", "Bearer "+a.OAuthToken)
+		// OAuth requires this beta header
+		h.Set("anthropic-beta", "oauth-2025-04-20")
+	} else if a.APIKey != "" {
+		h.Set("x-api-key", a.APIKey)
+	}
+}
+
+// streamBody copies src to dst, flushing after each read for SSE support.
+func streamBody(w http.ResponseWriter, src io.Reader) {
+	flusher, canFlush := w.(http.Flusher)
+	buf := make([]byte, 4096)
+	for {
+		n, err := src.Read(buf)
+		if n > 0 {
+			w.Write(buf[:n])
+			if canFlush {
+				flusher.Flush()
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+}
+
+func writeProxyError(w http.ResponseWriter, status int, errType string, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	fmt.Fprintf(w, `{"type":"error","error":{"type":"%s","message":"%s"}}`, errType, message)
+}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -478,25 +478,215 @@ func TestAugmented_NoDuplicateBetas(t *testing.T) {
 	}
 }
 
-func TestAugmented_ForwardsRequestBody(t *testing.T) {
-	var gotBody string
+func TestAugmented_InjectsAttribution(t *testing.T) {
+	var gotBody map[string]json.RawMessage
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		gotBody = string(body)
+		json.Unmarshal(body, &gotBody)
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"type":"message"}`))
 	}))
 	defer upstream.Close()
 
 	a := NewAugmented(AuthConfig{APIKey: "test-key"}, upstream.URL)
-	body := `{"model":"claude-sonnet-4","messages":[{"role":"user","content":"hello"}]}`
-	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(body))
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{"model":"claude-sonnet-4","messages":[{"role":"user","content":"hello world this is a test"}]}`))
 	w := httptest.NewRecorder()
 
 	a.Handle(w, req)
 
-	if gotBody != body {
-		t.Fatalf("request body not forwarded correctly:\nexpected: %s\ngot:      %s", body, gotBody)
+	// System prompt should be injected with attribution
+	system, ok := gotBody["system"]
+	if !ok {
+		t.Fatal("expected system field in forwarded body")
+	}
+
+	var systemBlocks []map[string]string
+	if err := json.Unmarshal(system, &systemBlocks); err != nil {
+		t.Fatalf("expected system as array of blocks: %v", err)
+	}
+
+	if len(systemBlocks) == 0 {
+		t.Fatal("expected at least one system block")
+	}
+
+	firstBlock := systemBlocks[0]["text"]
+	if !strings.Contains(firstBlock, "x-anthropic-billing-header:") {
+		t.Fatalf("expected attribution header in system prompt, got %q", firstBlock)
+	}
+	if !strings.Contains(firstBlock, "cc_version=") {
+		t.Fatalf("expected cc_version in attribution, got %q", firstBlock)
+	}
+	if !strings.Contains(firstBlock, "cc_entrypoint=cli") {
+		t.Fatalf("expected cc_entrypoint=cli in attribution, got %q", firstBlock)
+	}
+	if !strings.Contains(firstBlock, "You are Claude Code") {
+		t.Fatalf("expected Claude Code prefix in system prompt, got %q", firstBlock)
+	}
+}
+
+func TestAugmented_InjectsMetadata(t *testing.T) {
+	var gotBody map[string]json.RawMessage
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	a := NewAugmented(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{"model":"claude-sonnet-4","messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+
+	a.Handle(w, req)
+
+	metaRaw, ok := gotBody["metadata"]
+	if !ok {
+		t.Fatal("expected metadata field in forwarded body")
+	}
+
+	var metadata map[string]string
+	if err := json.Unmarshal(metaRaw, &metadata); err != nil {
+		t.Fatalf("failed to parse metadata: %v", err)
+	}
+
+	userID, ok := metadata["user_id"]
+	if !ok {
+		t.Fatal("expected user_id in metadata")
+	}
+
+	var userIDObj map[string]string
+	if err := json.Unmarshal([]byte(userID), &userIDObj); err != nil {
+		t.Fatalf("expected user_id to be JSON, got %q", userID)
+	}
+
+	if userIDObj["device_id"] == "" {
+		t.Fatal("expected non-empty device_id")
+	}
+	if userIDObj["session_id"] == "" {
+		t.Fatal("expected non-empty session_id")
+	}
+}
+
+func TestAugmented_PreservesExistingSystemString(t *testing.T) {
+	var gotBody map[string]json.RawMessage
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	a := NewAugmented(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{"model":"claude-sonnet-4","system":"You are a pirate","messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+
+	a.Handle(w, req)
+
+	var systemStr string
+	if err := json.Unmarshal(gotBody["system"], &systemStr); err != nil {
+		t.Fatalf("expected system as string: %v", err)
+	}
+
+	if !strings.Contains(systemStr, "x-anthropic-billing-header:") {
+		t.Fatalf("expected attribution in system, got %q", systemStr)
+	}
+	if !strings.Contains(systemStr, "You are a pirate") {
+		t.Fatalf("expected original system prompt preserved, got %q", systemStr)
+	}
+}
+
+func TestAugmented_PreservesExistingSystemArray(t *testing.T) {
+	var gotBody map[string]json.RawMessage
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	a := NewAugmented(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{"model":"claude-sonnet-4","system":[{"type":"text","text":"You are a pirate"}],"messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+
+	a.Handle(w, req)
+
+	var blocks []map[string]string
+	if err := json.Unmarshal(gotBody["system"], &blocks); err != nil {
+		t.Fatalf("expected system as array: %v", err)
+	}
+
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 system blocks (attribution + original), got %d", len(blocks))
+	}
+	if !strings.Contains(blocks[0]["text"], "x-anthropic-billing-header:") {
+		t.Fatalf("expected attribution in first block, got %q", blocks[0]["text"])
+	}
+	if blocks[1]["text"] != "You are a pirate" {
+		t.Fatalf("expected original system prompt in second block, got %q", blocks[1]["text"])
+	}
+}
+
+func TestAugmented_PreservesMessages(t *testing.T) {
+	var gotBody map[string]json.RawMessage
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	a := NewAugmented(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{"model":"claude-sonnet-4","messages":[{"role":"user","content":"hello"}]}`))
+	w := httptest.NewRecorder()
+
+	a.Handle(w, req)
+
+	// Messages should be preserved unchanged
+	var messages []map[string]interface{}
+	json.Unmarshal(gotBody["messages"], &messages)
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+	if messages[0]["content"] != "hello" {
+		t.Fatalf("expected message content 'hello', got %v", messages[0]["content"])
+	}
+}
+
+// --- computeFingerprint tests ---
+
+func TestComputeFingerprint(t *testing.T) {
+	// The fingerprint should be 3 hex chars
+	fp := computeFingerprint("hello world this is a test", "2.1.91")
+	if len(fp) != 3 {
+		t.Fatalf("expected 3-char fingerprint, got %q (len %d)", fp, len(fp))
+	}
+
+	// Same input should produce same output
+	fp2 := computeFingerprint("hello world this is a test", "2.1.91")
+	if fp != fp2 {
+		t.Fatalf("expected deterministic fingerprint, got %q and %q", fp, fp2)
+	}
+
+	// Different input should produce different output
+	fp3 := computeFingerprint("different message text here", "2.1.91")
+	if fp == fp3 {
+		t.Logf("warning: different messages produced same fingerprint %q (unlikely but possible)", fp)
+	}
+
+	// Short message (< 21 chars) should still work
+	fp4 := computeFingerprint("hi", "2.1.91")
+	if len(fp4) != 3 {
+		t.Fatalf("expected 3-char fingerprint for short message, got %q", fp4)
+	}
+
+	// Empty message should work
+	fp5 := computeFingerprint("", "2.1.91")
+	if len(fp5) != 3 {
+		t.Fatalf("expected 3-char fingerprint for empty message, got %q", fp5)
 	}
 }
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,0 +1,664 @@
+package proxy
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// --- Passthrough tests ---
+
+func TestPassthrough_ForwardsRequestBody(t *testing.T) {
+	var gotBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"text","text":"hello"}],"model":"claude-sonnet-4","stop_reason":"end_turn"}`))
+	}))
+	defer upstream.Close()
+
+	p := NewPassthrough(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{"model":"claude-sonnet-4","messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+
+	p.Handle(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if gotBody != `{"model":"claude-sonnet-4","messages":[{"role":"user","content":"hi"}]}` {
+		t.Fatalf("request body not forwarded correctly: %s", gotBody)
+	}
+}
+
+func TestPassthrough_InjectsAuthHeaders(t *testing.T) {
+	var gotHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	p := NewPassthrough(AuthConfig{APIKey: "sk-ant-test-key"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+
+	p.Handle(w, req)
+
+	if got := gotHeaders.Get("x-api-key"); got != "sk-ant-test-key" {
+		t.Fatalf("expected x-api-key 'sk-ant-test-key', got %q", got)
+	}
+	if got := gotHeaders.Get("anthropic-version"); got != "2023-06-01" {
+		t.Fatalf("expected anthropic-version '2023-06-01', got %q", got)
+	}
+	if got := gotHeaders.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("expected Content-Type 'application/json', got %q", got)
+	}
+}
+
+func TestPassthrough_PassesThroughClientBetaHeaders(t *testing.T) {
+	var gotBeta string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBeta = r.Header.Get("anthropic-beta")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	p := NewPassthrough(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{}`))
+	req.Header.Set("anthropic-beta", "my-custom-beta-2025-01-01")
+	w := httptest.NewRecorder()
+
+	p.Handle(w, req)
+
+	if gotBeta != "my-custom-beta-2025-01-01" {
+		t.Fatalf("expected client beta header passed through, got %q", gotBeta)
+	}
+}
+
+func TestPassthrough_ForwardsResponseHeaders(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("x-request-id", "req-123")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	p := NewPassthrough(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+
+	p.Handle(w, req)
+
+	if got := w.Header().Get("x-request-id"); got != "req-123" {
+		t.Fatalf("expected response header x-request-id 'req-123', got %q", got)
+	}
+}
+
+func TestPassthrough_ForwardsUpstreamErrors(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(400)
+		w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"model is required"}}`))
+	}))
+	defer upstream.Close()
+
+	p := NewPassthrough(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+
+	p.Handle(w, req)
+
+	if w.Code != 400 {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "model is required") {
+		t.Fatalf("expected upstream error forwarded, got %s", w.Body.String())
+	}
+}
+
+func TestPassthrough_StreamingSSE(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("expected flusher support")
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+
+		events := []string{
+			`event: message_start` + "\n" + `data: {"type":"message_start"}` + "\n\n",
+			`event: content_block_delta` + "\n" + `data: {"type":"content_block_delta","delta":{"text":"Hi"}}` + "\n\n",
+			`event: message_stop` + "\n" + `data: {"type":"message_stop"}` + "\n\n",
+		}
+		for _, e := range events {
+			fmt.Fprint(w, e)
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	p := NewPassthrough(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{"stream":true}`))
+	w := httptest.NewRecorder()
+
+	p.Handle(w, req)
+
+	if ct := w.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("expected Content-Type text/event-stream, got %q", ct)
+	}
+
+	events := parseSSE(t, w.Body.String())
+	if len(events) != 3 {
+		t.Fatalf("expected 3 SSE events, got %d: %v", len(events), events)
+	}
+	if events[0].eventType != "message_start" {
+		t.Fatalf("expected first event message_start, got %q", events[0].eventType)
+	}
+	if events[2].eventType != "message_stop" {
+		t.Fatalf("expected last event message_stop, got %q", events[2].eventType)
+	}
+}
+
+func TestPassthrough_UpstreamConnectionError(t *testing.T) {
+	// Point to a non-existent server
+	p := NewPassthrough(AuthConfig{APIKey: "test-key"}, "http://127.0.0.1:1")
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+
+	p.Handle(w, req)
+
+	if w.Code != 502 {
+		t.Fatalf("expected 502, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "upstream request failed") {
+		t.Fatalf("expected upstream error message, got %s", w.Body.String())
+	}
+}
+
+func TestPassthrough_ClaudeCodeHeaders(t *testing.T) {
+	var gotHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	p := NewPassthrough(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+
+	p.Handle(w, req)
+
+	if got := gotHeaders.Get("x-app"); got != "cli" {
+		t.Fatalf("expected x-app 'cli', got %q", got)
+	}
+	if got := gotHeaders.Get("User-Agent"); !strings.HasPrefix(got, "claude-cli/") {
+		t.Fatalf("expected User-Agent starting with 'claude-cli/', got %q", got)
+	}
+	if !strings.Contains(gotHeaders.Get("User-Agent"), "(external, cli)") {
+		t.Fatalf("expected User-Agent to contain '(external, cli)', got %q", gotHeaders.Get("User-Agent"))
+	}
+	if got := gotHeaders.Get("X-Claude-Code-Session-Id"); got == "" {
+		t.Fatal("expected X-Claude-Code-Session-Id to be set")
+	}
+	if got := gotHeaders.Get("x-client-request-id"); got == "" {
+		t.Fatal("expected x-client-request-id to be set")
+	}
+}
+
+func TestPassthrough_SessionIdConsistent(t *testing.T) {
+	var ids []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ids = append(ids, r.Header.Get("X-Claude-Code-Session-Id"))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	p := NewPassthrough(AuthConfig{APIKey: "test-key"}, upstream.URL)
+
+	for range 3 {
+		req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		p.Handle(w, req)
+	}
+
+	if len(ids) != 3 {
+		t.Fatalf("expected 3 requests, got %d", len(ids))
+	}
+	if ids[0] != ids[1] || ids[1] != ids[2] {
+		t.Fatalf("expected same session ID across requests, got %v", ids)
+	}
+}
+
+func TestPassthrough_RequestIdUnique(t *testing.T) {
+	var ids []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ids = append(ids, r.Header.Get("x-client-request-id"))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	p := NewPassthrough(AuthConfig{APIKey: "test-key"}, upstream.URL)
+
+	for range 3 {
+		req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		p.Handle(w, req)
+	}
+
+	if len(ids) != 3 {
+		t.Fatalf("expected 3 requests, got %d", len(ids))
+	}
+	if ids[0] == ids[1] || ids[1] == ids[2] {
+		t.Fatalf("expected unique request IDs, got %v", ids)
+	}
+}
+
+func TestPassthrough_DefaultBaseURL(t *testing.T) {
+	p := NewPassthrough(AuthConfig{APIKey: "test-key"}, "")
+	if p.baseURL != "https://api.anthropic.com" {
+		t.Fatalf("expected default base URL, got %q", p.baseURL)
+	}
+}
+
+// --- OAuth auth tests ---
+
+func TestPassthrough_OAuthAuth(t *testing.T) {
+	var gotHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	p := NewPassthrough(AuthConfig{OAuthToken: "my-oauth-token"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+
+	p.Handle(w, req)
+
+	if got := gotHeaders.Get("Authorization"); got != "Bearer my-oauth-token" {
+		t.Fatalf("expected Authorization 'Bearer my-oauth-token', got %q", got)
+	}
+	if got := gotHeaders.Get("x-api-key"); got != "" {
+		t.Fatalf("expected no x-api-key with OAuth, got %q", got)
+	}
+	// OAuth beta header must be present
+	assertBetaContains(t, gotHeaders.Get("anthropic-beta"), "oauth-2025-04-20")
+}
+
+func TestPassthrough_OAuthMergesClientBetas(t *testing.T) {
+	var gotBeta string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBeta = r.Header.Get("anthropic-beta")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	p := NewPassthrough(AuthConfig{OAuthToken: "token"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{}`))
+	req.Header.Set("anthropic-beta", "my-custom-beta")
+	w := httptest.NewRecorder()
+
+	p.Handle(w, req)
+
+	assertBetaContains(t, gotBeta, "oauth-2025-04-20")
+	assertBetaContains(t, gotBeta, "my-custom-beta")
+}
+
+func TestAugmented_OAuthIncludesAllBetas(t *testing.T) {
+	var gotBeta string
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBeta = r.Header.Get("anthropic-beta")
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	a := NewAugmented(AuthConfig{OAuthToken: "my-token"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{"model":"claude-sonnet-4","messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+
+	a.Handle(w, req)
+
+	if gotAuth != "Bearer my-token" {
+		t.Fatalf("expected Bearer auth, got %q", gotAuth)
+	}
+	// Should have both OAuth beta and model betas
+	assertBetaContains(t, gotBeta, "oauth-2025-04-20")
+	assertBetaContains(t, gotBeta, "claude-code-20250219")
+	assertBetaContains(t, gotBeta, "interleaved-thinking-2025-05-14")
+}
+
+// --- Augmented tests ---
+
+func TestAugmented_InjectsBetaHeaders_Sonnet(t *testing.T) {
+	var gotBeta string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBeta = r.Header.Get("anthropic-beta")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	a := NewAugmented(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+
+	a.Handle(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	assertBetaContains(t, gotBeta, "claude-code-20250219")
+	assertBetaContains(t, gotBeta, "interleaved-thinking-2025-05-14")
+	assertBetaContains(t, gotBeta, "context-management-2025-06-27")
+}
+
+func TestAugmented_InjectsBetaHeaders_Opus(t *testing.T) {
+	var gotBeta string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBeta = r.Header.Get("anthropic-beta")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	a := NewAugmented(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{"model":"claude-opus-4-20250514","messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+
+	a.Handle(w, req)
+
+	assertBetaContains(t, gotBeta, "claude-code-20250219")
+	assertBetaContains(t, gotBeta, "interleaved-thinking-2025-05-14")
+}
+
+func TestAugmented_HaikuSkipsClaudeCodeBeta(t *testing.T) {
+	var gotBeta string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBeta = r.Header.Get("anthropic-beta")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	a := NewAugmented(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{"model":"claude-haiku-4-5-20251001","messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+
+	a.Handle(w, req)
+
+	assertBetaNotContains(t, gotBeta, "claude-code-20250219")
+	// Haiku 4.5 is still claude-4+, so it gets thinking headers
+	assertBetaContains(t, gotBeta, "interleaved-thinking-2025-05-14")
+}
+
+func TestAugmented_Claude3SkipsThinkingBetas(t *testing.T) {
+	var gotBeta string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBeta = r.Header.Get("anthropic-beta")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	a := NewAugmented(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{"model":"claude-3-5-sonnet-20241022","messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+
+	a.Handle(w, req)
+
+	// Claude 3 models get claude-code but not thinking/context-management
+	assertBetaContains(t, gotBeta, "claude-code-20250219")
+	assertBetaNotContains(t, gotBeta, "interleaved-thinking-2025-05-14")
+	assertBetaNotContains(t, gotBeta, "context-management-2025-06-27")
+}
+
+func TestAugmented_MergesClientBetas(t *testing.T) {
+	var gotBeta string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBeta = r.Header.Get("anthropic-beta")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	a := NewAugmented(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{"model":"claude-sonnet-4","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("anthropic-beta", "my-custom-beta")
+	w := httptest.NewRecorder()
+
+	a.Handle(w, req)
+
+	// Client beta should be preserved
+	assertBetaContains(t, gotBeta, "my-custom-beta")
+	// Injected betas should also be present
+	assertBetaContains(t, gotBeta, "claude-code-20250219")
+}
+
+func TestAugmented_NoDuplicateBetas(t *testing.T) {
+	var gotBeta string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBeta = r.Header.Get("anthropic-beta")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	a := NewAugmented(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	// Client already provides claude-code-20250219
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{"model":"claude-sonnet-4","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("anthropic-beta", "claude-code-20250219")
+	w := httptest.NewRecorder()
+
+	a.Handle(w, req)
+
+	// Should only appear once
+	count := strings.Count(gotBeta, "claude-code-20250219")
+	if count != 1 {
+		t.Fatalf("expected claude-code-20250219 exactly once, found %d times in %q", count, gotBeta)
+	}
+}
+
+func TestAugmented_ForwardsRequestBody(t *testing.T) {
+	var gotBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	a := NewAugmented(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	body := `{"model":"claude-sonnet-4","messages":[{"role":"user","content":"hello"}]}`
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	a.Handle(w, req)
+
+	if gotBody != body {
+		t.Fatalf("request body not forwarded correctly:\nexpected: %s\ngot:      %s", body, gotBody)
+	}
+}
+
+// --- betaHeadersForModel tests ---
+
+func TestBetaHeadersForModel(t *testing.T) {
+	tests := []struct {
+		model    string
+		contains []string
+		excludes []string
+	}{
+		{
+			model:    "claude-sonnet-4-20250514",
+			contains: []string{"claude-code-20250219", "interleaved-thinking-2025-05-14", "context-management-2025-06-27"},
+		},
+		{
+			model:    "claude-opus-4",
+			contains: []string{"claude-code-20250219", "interleaved-thinking-2025-05-14", "context-management-2025-06-27"},
+		},
+		{
+			model:    "claude-haiku-4-5-20251001",
+			contains: []string{"interleaved-thinking-2025-05-14", "context-management-2025-06-27"},
+			excludes: []string{"claude-code-20250219"},
+		},
+		{
+			model:    "claude-3-5-sonnet-20241022",
+			contains: []string{"claude-code-20250219"},
+			excludes: []string{"interleaved-thinking-2025-05-14", "context-management-2025-06-27"},
+		},
+		{
+			model:    "",
+			contains: []string{"claude-code-20250219", "interleaved-thinking-2025-05-14"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			betas := betaHeadersForModel(tt.model)
+			betaSet := make(map[string]bool)
+			for _, b := range betas {
+				betaSet[b] = true
+			}
+
+			for _, want := range tt.contains {
+				if !betaSet[want] {
+					t.Errorf("expected beta %q for model %q, got %v", want, tt.model, betas)
+				}
+			}
+			for _, notWant := range tt.excludes {
+				if betaSet[notWant] {
+					t.Errorf("did not expect beta %q for model %q, got %v", notWant, tt.model, betas)
+				}
+			}
+		})
+	}
+}
+
+// --- mergeBetas tests ---
+
+func TestMergeBetas(t *testing.T) {
+	tests := []struct {
+		name       string
+		existing   string
+		additional []string
+		want       string
+	}{
+		{"empty both", "", nil, ""},
+		{"empty existing", "", []string{"a", "b"}, "a,b"},
+		{"empty additional", "a,b", nil, "a,b"},
+		{"merge without duplicates", "a,b", []string{"c", "d"}, "a,b,c,d"},
+		{"dedup", "a,b", []string{"b", "c"}, "a,b,c"},
+		{"whitespace handling", " a , b ", []string{"c"}, "a,b,c"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeBetas(tt.existing, tt.additional)
+			if got != tt.want {
+				t.Fatalf("mergeBetas(%q, %v) = %q, want %q", tt.existing, tt.additional, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Integration: server-level tests ---
+
+func TestPassthrough_ViaServer(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id": "msg_test", "type": "message", "role": "assistant",
+			"content":     []map[string]string{{"type": "text", "text": "hello from upstream"}},
+			"model":       "claude-sonnet-4",
+			"stop_reason": "end_turn",
+		})
+	}))
+	defer upstream.Close()
+
+	p := NewPassthrough(AuthConfig{APIKey: "test-key"}, upstream.URL)
+	ts := httptest.NewServer(http.HandlerFunc(p.Handle))
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL, "application/json", strings.NewReader(`{"model":"claude-sonnet-4","messages":[{"role":"user","content":"hi"}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result["type"] != "message" {
+		t.Fatalf("expected type 'message', got %v", result["type"])
+	}
+}
+
+// --- SSE parsing helper ---
+
+type sseEvent struct {
+	eventType string
+	data      string
+}
+
+func parseSSE(t *testing.T, body string) []sseEvent {
+	t.Helper()
+	var events []sseEvent
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	var current sseEvent
+	for scanner.Scan() {
+		line := scanner.Text()
+		if after, ok := strings.CutPrefix(line, "event: "); ok {
+			current.eventType = after
+		} else if after, ok := strings.CutPrefix(line, "data: "); ok {
+			current.data = after
+		} else if line == "" && current.eventType != "" {
+			events = append(events, current)
+			current = sseEvent{}
+		}
+	}
+	return events
+}
+
+func assertBetaContains(t *testing.T, betaHeader, want string) {
+	t.Helper()
+	for _, b := range strings.Split(betaHeader, ",") {
+		if strings.TrimSpace(b) == want {
+			return
+		}
+	}
+	t.Errorf("expected beta header to contain %q, got %q", want, betaHeader)
+}
+
+func assertBetaNotContains(t *testing.T, betaHeader, notWant string) {
+	t.Helper()
+	for _, b := range strings.Split(betaHeader, ",") {
+		if strings.TrimSpace(b) == notWant {
+			t.Errorf("expected beta header NOT to contain %q, got %q", notWant, betaHeader)
+			return
+		}
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -16,50 +16,54 @@ func (s *Server) HealthHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(`{"status":"ok"}`))
 }
 
-func (s *Server) MessagesHandler(w http.ResponseWriter, r *http.Request) {
-	var req types.MessagesRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "invalid request body: "+err.Error())
-		return
-	}
+// makeCLIHandler returns an http.HandlerFunc that handles Messages API requests
+// by shelling out to the Claude CLI via the given runner.
+func (s *Server) makeCLIHandler(runner claude.Runner) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req types.MessagesRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request_error", "invalid request body: "+err.Error())
+			return
+		}
 
-	if req.Model == "" {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "model is required")
-		return
-	}
-	if len(req.Messages) == 0 {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "messages is required")
-		return
-	}
+		if req.Model == "" {
+			writeError(w, http.StatusBadRequest, "invalid_request_error", "model is required")
+			return
+		}
+		if len(req.Messages) == 0 {
+			writeError(w, http.StatusBadRequest, "invalid_request_error", "messages is required")
+			return
+		}
 
-	cliModel, err := claude.MapModel(req.Model)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
-		return
-	}
+		cliModel, err := claude.MapModel(req.Model)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+			return
+		}
 
-	prompt, tempFiles, err := converter.ConvertMessages(req.System, req.Messages)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "api_error", "converting messages: "+err.Error())
-		return
-	}
-	defer media.Cleanup(tempFiles)
+		prompt, tempFiles, err := converter.ConvertMessages(req.System, req.Messages)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "api_error", "converting messages: "+err.Error())
+			return
+		}
+		defer media.Cleanup(tempFiles)
 
-	// Determine temp dir for --add-dir flag
-	tempDir := ""
-	if len(tempFiles) > 0 {
-		tempDir = media.TempDir
-	}
+		// Determine temp dir for --add-dir flag
+		tempDir := ""
+		if len(tempFiles) > 0 {
+			tempDir = media.TempDir
+		}
 
-	if req.Stream {
-		s.handleStreaming(w, r, cliModel, prompt, tempDir)
-	} else {
-		s.handleNonStreaming(w, r, req.Model, cliModel, prompt, tempDir)
+		if req.Stream {
+			handleCLIStreaming(w, r, runner, cliModel, prompt, tempDir)
+		} else {
+			handleCLINonStreaming(w, r, runner, req.Model, cliModel, prompt, tempDir)
+		}
 	}
 }
 
-func (s *Server) handleNonStreaming(w http.ResponseWriter, r *http.Request, apiModel, cliModel, prompt, tempDir string) {
-	result, err := s.runner.Run(r.Context(), cliModel, prompt, tempDir)
+func handleCLINonStreaming(w http.ResponseWriter, r *http.Request, runner claude.Runner, apiModel, cliModel, prompt, tempDir string) {
+	result, err := runner.Run(r.Context(), cliModel, prompt, tempDir)
 	if err != nil {
 		log.Printf("CLI error: %v", err)
 		writeError(w, http.StatusInternalServerError, "api_error", "claude CLI error: "+err.Error())
@@ -71,8 +75,8 @@ func (s *Server) handleNonStreaming(w http.ResponseWriter, r *http.Request, apiM
 	json.NewEncoder(w).Encode(resp)
 }
 
-func (s *Server) handleStreaming(w http.ResponseWriter, r *http.Request, cliModel, prompt, tempDir string) {
-	stdout, wait, err := s.runner.RunStreaming(r.Context(), cliModel, prompt, tempDir)
+func handleCLIStreaming(w http.ResponseWriter, r *http.Request, runner claude.Runner, cliModel, prompt, tempDir string) {
+	stdout, wait, err := runner.RunStreaming(r.Context(), cliModel, prompt, tempDir)
 	if err != nil {
 		log.Printf("CLI streaming error: %v", err)
 		writeError(w, http.StatusInternalServerError, "api_error", "claude CLI error: "+err.Error())

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -69,9 +69,9 @@ func mockStreamEvent(event string) string {
 func testServer(runner *fakeRunner) (*httptest.Server, *fakeRunner) {
 	var srv *Server
 	if isRealCLI() {
-		srv = New("127.0.0.1", 0, 10)
+		srv = NewCLI("127.0.0.1", 0, 10)
 	} else {
-		srv = NewWithRunner("127.0.0.1", 0, runner)
+		srv = NewCLIWithRunner("127.0.0.1", 0, runner)
 	}
 	return httptest.NewServer(srv.Handler()), runner
 }
@@ -486,7 +486,7 @@ func TestE2E_Messages_AllModels(t *testing.T) {
 			runner := &fakeRunner{
 				result: &types.CLIResult{Result: "ok", StopReason: "end_turn"},
 			}
-			srv := NewWithRunner("127.0.0.1", 0, runner)
+			srv := NewCLIWithRunner("127.0.0.1", 0, runner)
 			ts := httptest.NewServer(srv.Handler())
 			defer ts.Close()
 
@@ -578,7 +578,7 @@ func TestE2E_Messages_CLIError(t *testing.T) {
 	}
 
 	runner := &fakeRunner{err: fmt.Errorf("CLI crashed")}
-	srv := NewWithRunner("127.0.0.1", 0, runner)
+	srv := NewCLIWithRunner("127.0.0.1", 0, runner)
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
@@ -699,7 +699,7 @@ func TestE2E_Messages_StreamingCLIError(t *testing.T) {
 	}
 
 	runner := &fakeRunner{err: fmt.Errorf("stream start failed")}
-	srv := NewWithRunner("127.0.0.1", 0, runner)
+	srv := NewCLIWithRunner("127.0.0.1", 0, runner)
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
@@ -754,7 +754,7 @@ func TestE2E_ConcurrencyLimit(t *testing.T) {
 	}
 
 	// maxConcurrent=1: all requests must serialize
-	srv := NewWithRunner("127.0.0.1", 0, slow)
+	srv := NewCLIWithRunner("127.0.0.1", 0, slow)
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
@@ -797,7 +797,7 @@ func TestE2E_ConcurrencyLimit_WithCLIRunner(t *testing.T) {
 	sem := make(chan struct{}, 1)
 	limited := &semRunner{inner: slow, sem: sem}
 
-	srv := NewWithRunner("127.0.0.1", 0, limited)
+	srv := NewCLIWithRunner("127.0.0.1", 0, limited)
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,27 +12,44 @@ import (
 	"time"
 
 	"claudecodeproxy/internal/claude"
+	"claudecodeproxy/internal/proxy"
 )
 
 type Server struct {
-	host   string
-	port   int
-	runner claude.Runner
+	host            string
+	port            int
+	messagesHandler http.HandlerFunc
 }
 
-func New(host string, port int, maxConcurrent int) *Server {
-	return &Server{host: host, port: port, runner: claude.NewCLIRunner(maxConcurrent)}
+// NewCLI creates a server in CLI mode (shells out to claude).
+func NewCLI(host string, port int, maxConcurrent int) *Server {
+	runner := claude.NewCLIRunner(maxConcurrent)
+	return NewCLIWithRunner(host, port, runner)
 }
 
-// NewWithRunner creates a server with a custom CLI runner (for testing).
-func NewWithRunner(host string, port int, runner claude.Runner) *Server {
-	return &Server{host: host, port: port, runner: runner}
+// NewCLIWithRunner creates a CLI-mode server with a custom runner (for testing).
+func NewCLIWithRunner(host string, port int, runner claude.Runner) *Server {
+	s := &Server{host: host, port: port}
+	s.messagesHandler = s.makeCLIHandler(runner)
+	return s
+}
+
+// NewPassthrough creates a server that forwards requests to the Anthropic API.
+func NewPassthrough(host string, port int, auth proxy.AuthConfig, baseURL string) *Server {
+	p := proxy.NewPassthrough(auth, baseURL)
+	return &Server{host: host, port: port, messagesHandler: p.Handle}
+}
+
+// NewAugmented creates a server that injects beta headers and forwards to the API.
+func NewAugmented(host string, port int, auth proxy.AuthConfig, baseURL string) *Server {
+	p := proxy.NewAugmented(auth, baseURL)
+	return &Server{host: host, port: port, messagesHandler: p.Handle}
 }
 
 // Handler returns the HTTP handler for use in tests.
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /v1/messages", s.MessagesHandler)
+	mux.HandleFunc("POST /v1/messages", s.messagesHandler)
 	mux.HandleFunc("GET /health", s.HealthHandler)
 	return mux
 }


### PR DESCRIPTION
## Summary

- **Two new proxy modes** alongside the existing CLI mode, selectable via `--mode`:
  - `passthrough`: Pure reverse proxy to `api.anthropic.com` — injects auth headers, forwards everything else unchanged
  - `augmented`: Passthrough + injects model-appropriate beta headers, attribution header in system prompt, fingerprint, metadata, and Claude Code identity headers
- **OAuth support**: Uses `CLAUDE_CODE_OAUTH_TOKEN` (Bearer auth + `oauth-2025-04-20` beta) with fallback to `ANTHROPIC_API_KEY`
- **Claude Code request fingerprinting**: Augmented mode replicates the full request signature — `User-Agent`, `x-app`, session/request IDs, `x-anthropic-billing-header` with SHA256 fingerprint, and `metadata.user_id`

### Usage

```bash
# Passthrough (just auth proxy)
CLAUDE_CODE_OAUTH_TOKEN=<token> claudecodeproxy --mode passthrough

# Augmented (full Claude Code impersonation)
CLAUDE_CODE_OAUTH_TOKEN=<token> claudecodeproxy --mode augmented

# CLI mode (existing, default)
CLAUDE_CODE_OAUTH_TOKEN=<token> claudecodeproxy --mode cli
```

## Test plan

- [x] All existing CLI-mode tests pass unchanged
- [x] Passthrough: auth injection, header forwarding, SSE streaming, upstream error forwarding
- [x] Augmented: beta header injection per model, attribution in system prompt, fingerprint computation (verified matching Claude Code's JS implementation), metadata injection, system prompt preservation (string and array formats)
- [x] OAuth: Bearer auth, oauth beta header, beta merging with client-provided betas
- [x] Session ID stability across requests, request ID uniqueness
- [ ] Manual test with real OAuth token against `api.anthropic.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)